### PR TITLE
fix(docs): fixing redirect to how_it_works on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 # <samp>🤔 HOW?</samp>
 
-<samp>To understand how EON works, take a look at the [documentation](https://github.com/saulojoab/eon/blob/main/docs/HOW_IT_WORKS.md).</samp>
+<samp>To understand how EON works, take a look at the [documentation](https://github.com/saulojoab/eon/blob/main/docs/english/HOW_IT_WORKS.md).</samp>
 
 # <samp>🤠 FEATURES</samp>
 


### PR DESCRIPTION
## Why?

I noticed that clicking to navigate to `HOW_IT_WORKS.md` from the main README file was returning a 404 page.

## What?

Fixed the URL that README navigates to.